### PR TITLE
Allow access to the network

### DIFF
--- a/io.github.nuttyartist.notes.yaml
+++ b/io.github.nuttyartist.notes.yaml
@@ -5,9 +5,10 @@ sdk: org.kde.Sdk
 command: notes
 
 finish-args:
-  - --share=ipc
-  - --socket=x11
   - --device=dri
+  - --share=ipc
+  - --share=network
+  - --socket=x11
   - --talk-name=org.kde.StatusNotifierWatcher
 
 modules:


### PR DESCRIPTION
We now need this permission for the Pro Activation feature to work.