### PR TITLE
Enable Wayland display server

### DIFF
--- a/io.github.nuttyartist.notes.yaml
+++ b/io.github.nuttyartist.notes.yaml
@@ -5,6 +5,8 @@ sdk: org.kde.Sdk
 command: notes
 
 finish-args:
+  - --socket=fallback-x11
+  - --socket=wayland
   - --device=dri
   - --share=ipc
   - --share=network


### PR DESCRIPTION
This PR makes the package able to connect to the Wayland display server in addition to Xorg. The biggest effect this has is that the application won't be blurry (or small) with high DPI scaling.