### PR TITLE
Update KDE runtime to 6.6

### DIFF
--- a/io.github.nuttyartist.notes.yaml
+++ b/io.github.nuttyartist.notes.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.nuttyartist.notes
 runtime: org.kde.Platform
-runtime-version: '6.4'
+runtime-version: '6.6'
 sdk: org.kde.Sdk
 command: notes
 


### PR DESCRIPTION
This update is long overdue, but it was being postponed on purpose, to avoid triggering this bug:

https://github.com/nuttyartist/notes/issues/611

That bug has been fixed in Qt 6.6.3, so now we can update.