### PR TITLE
Update KDE runtime to 6.7

### DIFF
--- a/io.github.nuttyartist.notes.yaml
+++ b/io.github.nuttyartist.notes.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.nuttyartist.notes
 runtime: org.kde.Platform
-runtime-version: '6.6'
+runtime-version: '6.7'
 sdk: org.kde.Sdk
 command: notes
 


### PR DESCRIPTION
I've been using Notes built with Qt 6.7.1 for a few days, and everything seems fine.

So let's upgrade!

Closes #9